### PR TITLE
Moving plugin to command/spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,10 @@
-require 'bundler/gem_tasks'
+begin
+
+  require "bundler/gem_tasks"
+
+rescue LoadError
+  $stderr.puts "\033[0;31m" \
+    "[!] Please install the bundler gem manually:\n" \
+    "    $ [sudo] gem install bundler" \
+    "\e[0m"
+end

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -1,1 +1,1 @@
-require 'pod/command/lib/testing'
+require 'pod/command/spec/testing'

--- a/lib/pod/command/spec/testing.rb
+++ b/lib/pod/command/spec/testing.rb
@@ -3,12 +3,12 @@ require 'xctasks/test_task'
 
 module Pod
   class Command
-    class Lib
+    class Spec
 
       # @todo Create a PR to add your plugin to CocoaPods/cocoapods.org
       #       in the `plugins.json` file, once your plugin is released.
 
-      class Testing < Lib
+      class Testing < Spec
         self.summary = 'Run tests for any pod from the command line without any prior knowledge.'
 
         def handle_workspace(workspace, workspace_location)


### PR DESCRIPTION
Moving the command/lib/testing to command/spec/testing, for a better coherence (or harmony, I'd say) of the plugin.
